### PR TITLE
Use id instead of name for anchor

### DIFF
--- a/pages/symbol_dock_widget.md
+++ b/pages/symbol_dock_widget.md
@@ -36,7 +36,7 @@ Text size may be approximated as 0.24 times the point size for a typical easy to
 <p><b>Combined symbols</b> are made up of two or more other line or area symbols. This is for example used to combine the gray fill and black outline for houses in sprint maps into a single symbol.</p>
 
 
-<a name="symbolmenu"><h4>Symbol menu</h4></a>
+<h4 id="symbolmenu">Symbol menu</h4>
 
 <p>To show the symbol menu, right click the symbol pane:</p>
 


### PR DESCRIPTION
The "<h4>" tags are showing up on the online version of this page (http://openorienteering.github.io/mapper-manual/pages/symbol_dock_widget.html) so this change is consistent with how it is done with other pages in the manual such as the Georeferencing page.
