### PR TITLE
Update canonical link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ project_url:    http://openorienteering.org/apps/mapper/
 title:          OpenOrienteering Mapper User Manual
 description:    Manual page for the Open Source mapping software
 baseurl:        /mapper-manual
-production_url: http://openorienteering.github.io/mapper-manual
+production_url: http://www.openorienteering.org/mapper-manual
 markdown:       kramdown
 exclude:
   - Gemfile


### PR DESCRIPTION
Before:
`<link rel="canonical" href="http://openorienteering.github.io/mapper-manual/pages/" />`
After:
`<link rel="canonical" href="http://www.openorienteering.org/mapper-manual/pages/" />`
More about [rel="canonical"](https://webmasters.googleblog.com/2009/02/specify-your-canonical.html).