### PR TITLE
Mapping introduction update

### DIFF
--- a/pages/mapping-introduction.md
+++ b/pages/mapping-introduction.md
@@ -88,7 +88,7 @@ The Print Tech Test Sheet is designed to demonstrate beneficial over-printing ef
 
 ## Map scales
 
-Map scales are set in accordance with the International Specification for Orienteering Maps (ISOM). The traditional competition format is at 1:15000. More recently maps may be printed at 1:10000 for shorter courses. Maps at 1:10k are visually identical to those at 1:15k. The ISOM emphatically requires that a larger scale 1:10k shall not be used in order to fit more detail onto the map but simply permits the map to be more easily read by older competitors who will generally have shorter courses and not require large maps. Sprint maps made to the ISSOM standard may be at either 1:5000 or 1:4000 and use a different symbol set appropriate to that scale.
+Map scales are set in accordance with the International Specification for Orienteering Maps (ISOM). The traditional competition format is at 1:15000. More recently maps may be printed at 1:10000 for shorter courses. Maps at 1:10k are visually identical to those at 1:15k. The ISOM emphatically requires that a larger scale 1:10k shall not be used in order to fit more detail onto the map but simply permits the map to be more easily read by older competitors who will generally have shorter courses and not require large maps. Sprint maps made to the ISSprOM standard may be at either 1:5000 or 1:4000 and use a different symbol set appropriate to that scale.
 
 Printing of a map prepared at 1:15000 may be at either scale (and conversely a map prepared at 1:10k can be printed at 1:15k) with no loss of accuracy or information. Most course planning software provides for this re-scaling at the point of printing.
 

--- a/pages/mapping-introduction.md
+++ b/pages/mapping-introduction.md
@@ -3,7 +3,7 @@ title: Introduction to mapping for orienteering
 author:
   - Thomas Schoeps
   - Kai Pastor
-last_modified_date: 1 December 2015
+last_modified_date: 26 January 2022
 nav_exclude: true
 ---
 
@@ -14,21 +14,21 @@ nav_exclude: true
 
 ## Topics to be covered
 
- - Suitability of orienteering terrains, permissions, scale.
+ - **Suitability of orienteering terrains, permissions, scale:**
    Things to consider before starting a new map.
- - Acquiring map templates (aka base maps)
+ - **Acquiring map templates (aka base maps):**
    Good templates save you lots of time, so it is often worth looking for the best templates available.
- - Loading and matching templates
+ - **Loading and matching templates:**
    After getting the templates, the map file is created where they need to be put into a common coordinate system.
- - Orienteering symbol sets
+ - **Orienteering symbol sets:**
    Before starting to map, you should become (more) familiar with the orienteering symbol sets.
- - Surveying: classic method
+ - **Surveying (classic method):**
    Surveying the terrain by printing out templates, drawing in map details, scanning your drawings and doing the final drawing at home.
- - Surveying: digital method
+ - **Surveying (digital method):**
    Surveying the terrain with help of mobile computers.
- - Drawing
+ - **Drawing:**
    Doing the final drawing with OpenOrienteering Mapper.
- - Generalization
+ - **Generalization:**
    The importance of generalization.
 
 ## Surveying (classic method)
@@ -45,11 +45,11 @@ Accurate mapping depends on high quality fieldwork. Ordinarily, fieldwork will u
 
 The fieldwork will usually be done at a larger scale than the final map. With convenient rescaling of computer graphic images it is now possible for fieldwork to be undertaken at any convenient scale such as 1:5000 or even larger. This demands less skill in field penmanship than the traditional fieldwork scale of 1:7500.
 
-The fieldwork is scanned &#8212; about 200dpi is usually quite sufficient resolution &#8212; now save the image as a .png file in your map file directory ( .jpg image files also work). This file is then loaded as a template underneath the new map screen and the features are inserted on the map on top of the fieldwork image. The fieldwork must be scaled and positioned appropriately for this purpose.
+The fieldwork is scanned - about 200dpi is usually quite sufficient resolution - now save the image as a .png file in your map file directory ( .jpg image files also work). This file is then loaded as a template underneath the new map screen and the features are inserted on the map on top of the fieldwork image. The fieldwork must be scaled and positioned appropriately for this purpose.
 
 ## Symbols
 
-Symbols for orienteering maps are prescribed in the [IOF documents](http://orienteering.org/resources/mapping/) ISOM (International Standard for Orienteering Maps), ISSOM (sprint maps), ISMTBOM (MTBO maps), and ISSkiOM (ski orienteering maps).
+Symbols for orienteering maps are prescribed in the [IOF documents](http://orienteering.org/resources/mapping/) ISOM (International Specification for Orienteering Maps), ISSprOM (sprint maps), ISMTBOM (MTBO maps), and ISSkiOM (ski orienteering maps).
 
 It is very desirable that all orienteering maps should conform to the appropriate standard, and that includes conforming to the standard symbols for the discipline.
 
@@ -71,12 +71,12 @@ With the advent of inexpensive ink-jet printers and high quality printing papers
 
 This tool defines colors in terms of the CMYK system or the RGB system. Default colors for orienteering maps are entered but the colors that are actually printed by a particular printer on a particular paper type can produce a result which is quite different from the PMS color intended.
 
-The IOF Map Commission has prepared an offset printed paper test sheet (Print Tech Test Sheet - available from your national mapping officer) and as a map file printtech2006.ocd (available as download from the [IOF](http://orienteering.org/resources/mapping/test-sheet-for-assessing-print-quality-for-orienteering-maps/).The offset printed paper sheet has the currently prescribed colors for the production of maps (Store in a heavy envelope, do not use copies which have been kept loose and may be faded). The colors for a particular printer and paper may be adjusted using the Color Window so that a better match with the offset printed test sheet is achieved. The colors yellow (open space on the terrain) and brown (contour lines) are commonly quite divergent from the standard.
+The IOF Map Commission has prepared an offset printed paper test sheet (Print Tech Test Sheet - available from your national mapping officer) and as a map file *PrintTech test sheet_ver 20190412_ocd11.ocd* (available as download from the [IOF](https://orienteering.sport/iof/mapping/)). The offset printed paper sheet has the currently prescribed colors for the production of maps (Store in a heavy envelope, do not use copies which have been kept loose and may be faded). The colors for a particular printer and paper may be adjusted using the Color Window so that a better match with the offset printed test sheet is achieved. The colors yellow (open space on the terrain) and brown (contour lines) are commonly quite divergent from the standard.
 
 ### Color adjustment
 
 1. Scan the IOF offset printed Print Tech page in any scanner and use a color picker to get the CMYK values on screen for each color. By way of example this scan may yield CMYK values of 000, .800, .991, .569 respectively for 100% brown.
-2. Load the file printtech2006.ocd file into OpenOrienteering Mapper and print the page on your printer. Take this freshly printed page and scan that print on the same scanner and use the same color picker to get the color values you have in the scan. An example of this scan for 100% brown may yield CMYK values of 000, .689, .942, .255 respectively.
+2. Load the file *PrintTech test sheet_ver 20190412_ocd11.ocd* into OpenOrienteering Mapper and print the page on your printer. Take this freshly printed page and scan that print on the same scanner and use the same color picker to get the color values you have in the scan. An example of this scan for 100% brown may yield CMYK values of 000, .689, .942, .255 respectively.
 3. The difference between those two sets of values will indicate the adjustments required. Using the example values the Color Window line for 100% brown should have no adjustment to the cyan field, +.111 to magenta, +.049 to yellow, and +.314 to black. Those adjustments must be made in the OpenOrienteering Mapper Color Window. Having made similar adjustments for all colors, then run the step 2 print trial again.
 4. In a perfect world the differences will all reduce to zero. In practice they may not because of non-linearities in the hardware and colors like brown are poorly defined on the color palette. Several iterations may be required to get a good match.
 
@@ -88,7 +88,7 @@ The Print Tech Test Sheet is designed to demonstrate beneficial over-printing ef
 
 ## Map scales
 
-Map scales are set in accordance with the International Standard for Orienteering Maps (ISOM). The traditional competition format is at 1:15000. More recently maps may be printed at 1:10000 for shorter courses. Maps at 1:10k are visually identical to those at 1:15k. The ISOM emphatically requires that a larger scale 1:10k shall not be used in order to fit more detail onto the map but simply permits the map to be more easily read by older competitors who will generally have shorter courses and not require large maps. Sprint maps made to the ISSOM standard may be at either 1:5000 or 1:4000 and use a different symbol set appropriate to that scale.
+Map scales are set in accordance with the International Specification for Orienteering Maps (ISOM). The traditional competition format is at 1:15000. More recently maps may be printed at 1:10000 for shorter courses. Maps at 1:10k are visually identical to those at 1:15k. The ISOM emphatically requires that a larger scale 1:10k shall not be used in order to fit more detail onto the map but simply permits the map to be more easily read by older competitors who will generally have shorter courses and not require large maps. Sprint maps made to the ISSOM standard may be at either 1:5000 or 1:4000 and use a different symbol set appropriate to that scale.
 
 Printing of a map prepared at 1:15000 may be at either scale (and conversely a map prepared at 1:10k can be printed at 1:15k) with no loss of accuracy or information. Most course planning software provides for this re-scaling at the point of printing.
 

--- a/pages/mapping-introduction.md
+++ b/pages/mapping-introduction.md
@@ -3,7 +3,7 @@ title: Introduction to mapping for orienteering
 author:
   - Thomas Schoeps
   - Kai Pastor
-last_modified_date: 26 January 2022
+last_modified_date: 30 May 2025
 nav_exclude: true
 ---
 

--- a/pages/mapping-introduction.md
+++ b/pages/mapping-introduction.md
@@ -49,7 +49,7 @@ The fieldwork is scanned - about 200dpi is usually quite sufficient resolution -
 
 ## Symbols
 
-Symbols for orienteering maps are prescribed in the [IOF documents](http://orienteering.org/resources/mapping/) ISOM (International Specification for Orienteering Maps), ISSprOM (sprint maps), ISMTBOM (MTBO maps), and ISSkiOM (ski orienteering maps).
+Symbols for orienteering maps are prescribed in the [IOF documents](https://orienteering.sport/iof/mapping/) ISOM (International Specification for Orienteering Maps), ISSprOM (Sprint maps), ISMTBOM (MTBO maps), and ISSkiOM (Ski orienteering maps).
 
 It is very desirable that all orienteering maps should conform to the appropriate standard, and that includes conforming to the standard symbols for the discipline.
 
@@ -71,12 +71,12 @@ With the advent of inexpensive ink-jet printers and high quality printing papers
 
 This tool defines colors in terms of the CMYK system or the RGB system. Default colors for orienteering maps are entered but the colors that are actually printed by a particular printer on a particular paper type can produce a result which is quite different from the PMS color intended.
 
-The IOF Map Commission has prepared an offset printed paper test sheet (Print Tech Test Sheet - available from your national mapping officer) and as a map file *PrintTech test sheet_ver 20190412_ocd11.ocd* (available as download from the [IOF](https://orienteering.sport/iof/mapping/)). The offset printed paper sheet has the currently prescribed colors for the production of maps (Store in a heavy envelope, do not use copies which have been kept loose and may be faded). The colors for a particular printer and paper may be adjusted using the Color Window so that a better match with the offset printed test sheet is achieved. The colors yellow (open space on the terrain) and brown (contour lines) are commonly quite divergent from the standard.
+The IOF Map Commission has prepared an offset printed paper test sheet (IOF Print Test Sheet - available from your national mapping officer) and as a map file *PrintTestSheet_2025_v1.omap* (available as download from the [IOF](https://orienteering.sport/iof/mapping/)). The offset printed paper sheet has the currently prescribed colors for the production of maps (Store in a heavy envelope, do not use copies which have been kept loose and may be faded). The colors for a particular printer and paper may be adjusted using the Color Window so that a better match with the offset printed test sheet is achieved. The colors yellow (open space on the terrain) and brown (contour lines) are commonly quite divergent from the standard.
 
 ### Color adjustment
 
-1. Scan the IOF offset printed Print Tech page in any scanner and use a color picker to get the CMYK values on screen for each color. By way of example this scan may yield CMYK values of 000, .800, .991, .569 respectively for 100% brown.
-2. Load the file *PrintTech test sheet_ver 20190412_ocd11.ocd* into OpenOrienteering Mapper and print the page on your printer. Take this freshly printed page and scan that print on the same scanner and use the same color picker to get the color values you have in the scan. An example of this scan for 100% brown may yield CMYK values of 000, .689, .942, .255 respectively.
+1. Scan the offset printed IOF Print Test Sheet in any scanner and use a color picker to get the CMYK values on screen for each color. By way of example this scan may yield CMYK values of 000, .800, .991, .569 respectively for 100% brown.
+2. Load the file *PrintTestSheet_2025_v1.omap* into OpenOrienteering Mapper and print the page on your printer. Take this freshly printed page and scan that print on the same scanner and use the same color picker to get the color values you have in the scan. An example of this scan for 100% brown may yield CMYK values of 000, .689, .942, .255 respectively.
 3. The difference between those two sets of values will indicate the adjustments required. Using the example values the Color Window line for 100% brown should have no adjustment to the cyan field, +.111 to magenta, +.049 to yellow, and +.314 to black. Those adjustments must be made in the OpenOrienteering Mapper Color Window. Having made similar adjustments for all colors, then run the step 2 print trial again.
 4. In a perfect world the differences will all reduce to zero. In practice they may not because of non-linearities in the hardware and colors like brown are poorly defined on the color palette. Several iterations may be required to get a good match.
 
@@ -84,7 +84,7 @@ The same general approach may be employed but using the RGB color space instead.
 
 When a contour is printed in an area of green on the map the brown of the contour loses contrast and the contour line becomes harder to see.  If the map is offset printed the green is laid down without a gap and the brown is printed over it while the green ink is still wet, with the result that the green and brown blend together where they are coincident. This creates a segment of line which is somewhat darker than the 100% brown line outside the green and the darker color is noted to be easier to see. This very desirable result is called an over-printing effect.
 
-The Print Tech Test Sheet is designed to demonstrate beneficial over-printing effects where these are achieved. Consider the visibility of the wavy contour lines (and blue creek lines) printed against a variety of backgrounds on the lower left of the sheet.
+The Print Test Sheet is designed to demonstrate beneficial over-printing effects where these are achieved. Consider the visibility of the wavy contour lines (and blue creek lines) printed against a variety of backgrounds on the lower left of the sheet.
 
 ## Map scales
 

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -132,6 +132,7 @@ txt
 UI
 UTM
 v0
+v1
 v7a
 v8a
 vectorization

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -72,6 +72,7 @@ ISOM2017
 isotropically
 ISSkiOM
 ISSOM
+ISSprOM
 JPEG2000
 jpg
 JPG
@@ -109,7 +110,7 @@ pixelated
 png
 PNG
 pre
-printtech2006
+PrintTestSheet
 Proj
 PROJ
 repositions


### PR DESCRIPTION
- Update of ISOM abbreviation (International Specification for Orienteering Maps)
- Replacement of ISSOM by ISSprOM
- Update of link and name of current Print Tech Test Sheet
- Update of some formatting (e.g., &#8212; is not shown as a long dash under Windows).
- Formatting of "Topics to be covered" section changed.