### PR TITLE
CI: Update spell checking installation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,11 @@ jobs:
 
     # https://facelessuser.github.io/pyspelling/#usage-in-ci
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: 3.12
     - name: Install pyspelling
       run: |
         python -m pip install --upgrade pip setuptools

--- a/.pyspelling.yml
+++ b/.pyspelling.yml
@@ -6,6 +6,12 @@ matrix:
     output: wordlist.dic
     encoding: utf-8
   pipeline:
+  - pyspelling.filters.context:
+      context_visible_first: true
+      delimiters:
+      # Ignore possessive endings
+      - open: '(?<=\w)''s(?!\w)'
+        close: '\b'
   - pyspelling.filters.markdown:
       markdown_extensions:
       - attr_list:


### PR DESCRIPTION
Upgrade from Python version 3.7 which has status EOL: [Python 3.7.x will be removed from January 10 ,2025](https://github.com/actions/runner-images/issues/10893).
Commit is based on [setup-python](https://github.com/actions/setup-python).
Moving to Python 3.12 instead of 3.13 as [pyspelling](https://pypi.org/project/pyspelling/) mentions 3.12 but not yet 3.13.
